### PR TITLE
chore: update script and pipeline to be more explicit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,12 +26,13 @@ runs:
         SCRIPT_PATH="${SCRIPT_HOME}o_and_m.sh"
         chmod +x $SCRIPT_PATH
         o_and_m_files=$(${SCRIPT_PATH} ${{ inputs.operation_path }})
+        o_and_m_files_updated=$(${SCRIPT_PATH} ${{ inputs.operation_path }} | tail -n 1) # get only true/false
         echo "O and M files: $o_and_m_files"
-        if [ -z "$o_and_m_files" ]; then
-          echo "$o_and_m_files"
-          echo "o_and_m_files=false" >> $GITHUB_OUTPUT
+        if [ "$o_and_m_files_updated" == false ]; then
+          echo "o_and_m_files=false" >> "$GITHUB_OUTPUT"
+          echo "Approval workflow will NOT be triggered"
         else
-          echo "$o_and_m_files"
-          echo "o_and_m_files=true" >> $GITHUB_OUTPUT
+          echo "o_and_m_files=true" >> "$GITHUB_OUTPUT"
+          echo "Approval workflow WILL BE triggered"
         fi
       shell: bash

--- a/scripts/o_and_m.sh
+++ b/scripts/o_and_m.sh
@@ -27,8 +27,7 @@ done
 if [ $instScript ]; then
     echo "O & M docs have been updated"
     echo "Files updated: ${instScript_files[@]}"
-    echo "Initiating approval flow"
-    # Initiate approval flow
+    echo "true"
 else
-    echo "O & M docs have not been updated"
+    echo "false"
 fi


### PR DESCRIPTION
This PR makes 2 updates:

1. **o_and_m.sh** | Update this script so that it explicitly outputs:
- 'true' in case there were changes to o&m documentation
- 'false' in case there were NO changes to o&m documentation

2. **action.yml** | Update pipeline script so that it 'parses' the final output `tail -n 1` of the previously mentioned script
- In case it's 'true' -> `echo "o_and_m_files=true" >> "$GITHUB_OUTPUT"`
- otherwise sets the output to false
- this will then be leveraged by the o&m job in the qms pipeline run which triggers the approval workflow or not depending on the output previously mentioned